### PR TITLE
Send the full comment object to `get_avatar()` rather than just the comment author's email address

### DIFF
--- a/includes/class-bwp-recent-comments.php
+++ b/includes/class-bwp-recent-comments.php
@@ -770,7 +770,7 @@ if (!empty($page))
 			) : $comment['author'];
 		// Avatar
 		$avatar_width = (!empty($this->options['input_gravatar_width'])) ? $this->options['input_gravatar_width'] : $this->options_default['input_gravatar_width'];
-		$comment['avatar'] 	= ($this->options['enable_gravatars'] == 'yes') ? get_avatar($commentdata['comment_author_email'], $avatar_width, apply_filters('bwp_rc_default_avatar', NULL), __('User Avatar', 'bwp-rc')) : '';
+		$comment['avatar'] 	= ($this->options['enable_gravatars'] == 'yes') ? get_avatar( (object) $commentdata, $avatar_width, apply_filters('bwp_rc_default_avatar', NULL), __('oUser Avatar', 'bwp-rc')) : '';
 		// Links to post or comment page - @since 1.1.0
 		$comment['post_link'] = get_permalink($commentdata['comment_post_ID']);
 		$comment['link'] 	= get_comment_link($commentdata['comment_ID'], array('type' => 'comment'));

--- a/includes/class-bwp-recent-comments.php
+++ b/includes/class-bwp-recent-comments.php
@@ -770,7 +770,7 @@ if (!empty($page))
 			) : $comment['author'];
 		// Avatar
 		$avatar_width = (!empty($this->options['input_gravatar_width'])) ? $this->options['input_gravatar_width'] : $this->options_default['input_gravatar_width'];
-		$comment['avatar'] 	= ($this->options['enable_gravatars'] == 'yes') ? get_avatar( (object) $commentdata, $avatar_width, apply_filters('bwp_rc_default_avatar', NULL), __('oUser Avatar', 'bwp-rc')) : '';
+		$comment['avatar'] 	= ($this->options['enable_gravatars'] == 'yes') ? get_avatar( (object) $commentdata, $avatar_width, apply_filters('bwp_rc_default_avatar', NULL), __('User Avatar', 'bwp-rc')) : '';
 		// Links to post or comment page - @since 1.1.0
 		$comment['post_link'] = get_permalink($commentdata['comment_post_ID']);
 		$comment['link'] 	= get_comment_link($commentdata['comment_ID'], array('type' => 'comment'));


### PR DESCRIPTION
`get_avatar()` can accept a user ID, email address, or comment object.  It's best to use a comment object because it provides the most context to plugins which use the `get_avatar` filter to change the response of the `get_avatar()` function.

Note that core WordPress always sends the full comment object to `get_avatar()` when rendering comment avatars.

Jetpack uses the `get_avatar` filter to replace the default avatar with the Twitter or Facebook avatar for comments submitted using Twitter or Facebook authentication.  Jetpack needs the full comment object to do this.
